### PR TITLE
Fix fallback pointer formatting on big endian

### DIFF
--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -239,7 +239,7 @@ FMT_FUNC void system_error::init(int err_code, string_view format_str,
 namespace internal {
 
 template <> FMT_FUNC int count_digits<4>(internal::fallback_uintptr n) {
-  // Assume little endian; pointer formatting is implementation-defined anyway.
+  // fallback_uintptr is always stored in little endian.
   int i = static_cast<int>(sizeof(void*)) - 1;
   while (i > 0 && n.value[i] == 0) --i;
   auto char_digits = std::numeric_limits<unsigned char>::digits / 4;

--- a/test/format-impl-test.cc
+++ b/test/format-impl-test.cc
@@ -447,7 +447,7 @@ TEST(UtilTest, CountDigits) {
 TEST(UtilTest, WriteUIntPtr) {
   fmt::memory_buffer buf;
   fmt::internal::writer writer(buf);
-  writer.write_pointer(fmt::internal::bit_cast<fmt::internal::fallback_uintptr>(
+  writer.write_pointer(fmt::internal::fallback_uintptr(
                            reinterpret_cast<void*>(0xface)),
                        nullptr);
   EXPECT_EQ("0xface", to_string(buf));


### PR DESCRIPTION
<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
