### PR TITLE
Fix handling of types convertible to std::string_view

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -878,9 +878,7 @@ template <typename Context> struct arg_mapper {
       FMT_ENABLE_IF(
           std::is_constructible<std_string_view<char_type>, T>::value &&
           !std::is_constructible<basic_string_view<char_type>, T>::value &&
-          !is_string<T>::value &&
-          !has_formatter<T, Context>::value &&
-          !has_fallback_formatter<T, Context>::value)>
+          !is_string<T>::value && !has_formatter<T, Context>::value)>
   FMT_CONSTEXPR basic_string_view<char_type> map(const T& val) {
     return std_string_view<char_type>(val);
   }
@@ -913,12 +911,14 @@ template <typename Context> struct arg_mapper {
       map(static_cast<typename std::underlying_type<T>::type>(val))) {
     return map(static_cast<typename std::underlying_type<T>::type>(val));
   }
-  template <typename T,
-            FMT_ENABLE_IF(!is_string<T>::value && !is_char<T>::value &&
-                          !std::is_constructible<basic_string_view<char_type>,
-                                                 T>::value &&
-                          (has_formatter<T, Context>::value ||
-                           has_fallback_formatter<T, Context>::value))>
+  template <
+      typename T,
+      FMT_ENABLE_IF(
+          !is_string<T>::value && !is_char<T>::value &&
+          !std::is_constructible<basic_string_view<char_type>, T>::value &&
+          (has_formatter<T, Context>::value ||
+           (has_fallback_formatter<T, Context>::value &&
+            !std::is_constructible<std_string_view<char_type>, T>::value)))>
   FMT_CONSTEXPR const T& map(const T& val) {
     return val;
   }

--- a/test/format-test.cc
+++ b/test/format-test.cc
@@ -1691,16 +1691,14 @@ struct explicitly_convertible_to_std_string_view {
 };
 
 namespace fmt {
-
 template <>
 struct formatter<explicitly_convertible_to_std_string_view>
     : formatter<std::string_view> {
   auto format(const explicitly_convertible_to_std_string_view& v,
-              format_context& ctx) {
+              format_context& ctx) -> decltype(ctx.out()) {
     return format_to(ctx.out(), "'{}'", std::string_view(v));
   }
 };
-
 }  // namespace fmt
 
 TEST(FormatterTest, FormatExplicitlyConvertibleToStdStringView) {

--- a/test/ostream-test.cc
+++ b/test/ostream-test.cc
@@ -276,3 +276,25 @@ std::ostream& operator<<(std::ostream& os,
 TEST(FormatterTest, FormatExplicitlyConvertibleToStringLikeIgnoreInserter) {
   EXPECT_EQ("foo", fmt::format("{}", explicitly_convertible_to_string_like()));
 }
+
+#ifdef FMT_USE_STRING_VIEW
+struct explicitly_convertible_to_std_string_view {
+  explicit operator fmt::internal::std_string_view<char>() const {
+    return {"foo", 3u};
+  }
+};
+
+TEST(FormatterTest, FormatExplicitlyConvertibleToStdStringView) {
+  EXPECT_EQ("foo", fmt::format("{}", explicitly_convertible_to_string_like()));
+}
+
+std::ostream& operator<<(std::ostream& os,
+                         explicitly_convertible_to_std_string_view) {
+  return os << "bar";
+}
+
+TEST(FormatterTest, FormatExplicitlyConvertibleToStdStringViewIgnoreInserter) {
+  EXPECT_EQ("foo",
+            fmt::format("{}", explicitly_convertible_to_std_string_view()));
+}
+#endif  // FMT_USE_STRING_VIEW


### PR DESCRIPTION
<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
