### PR TITLE
Extend FMT_FALLTHROUGH compatibily to gcc and clang pre-C++17 (#1469)

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -69,9 +69,17 @@
 #  define FMT_HAS_BUILTIN(x) 0
 #endif
 
-#if FMT_HAS_CPP_ATTRIBUTE(fallthrough) && \
-    (__cplusplus >= 201703 || FMT_GCC_VERSION != 0)
-#  define FMT_FALLTHROUGH [[fallthrough]]
+#if __cplusplus  == 201103L || __cplusplus  == 201402L
+#  if defined(__clang__)
+#    define FMT_FALLTHROUGH [[clang::fallthrough]];
+#  elif FMT_GCC_VERSION >= 700
+#    define FMT_FALLTHROUGH [[gnu::fallthrough]];
+#  else
+#    define FMT_FALLTHROUGH
+#  endif
+#elif FMT_HAS_CPP_ATTRIBUTE(fallthrough) && \
+     ((__cplusplus >= 201703) || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L))
+#  define FMT_FALLTHROUGH [[fallthrough]];
 #else
 #  define FMT_FALLTHROUGH
 #endif


### PR DESCRIPTION
<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
