### PR TITLE
warning C4468: 'fallthrough': attribute must be followed by a case la…

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -71,15 +71,15 @@
 
 #if __cplusplus  == 201103L || __cplusplus  == 201402L
 #  if defined(__clang__)
-#    define FMT_FALLTHROUGH [[clang::fallthrough]];
+#    define FMT_FALLTHROUGH [[clang::fallthrough]]
 #  elif FMT_GCC_VERSION >= 700
-#    define FMT_FALLTHROUGH [[gnu::fallthrough]];
+#    define FMT_FALLTHROUGH [[gnu::fallthrough]]
 #  else
 #    define FMT_FALLTHROUGH
 #  endif
-#elif FMT_HAS_CPP_ATTRIBUTE(fallthrough) && \
-     ((__cplusplus >= 201703) || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L))
-#  define FMT_FALLTHROUGH [[fallthrough]];
+#elif (FMT_HAS_CPP_ATTRIBUTE(fallthrough) && (__cplusplus >= 201703)) || \
+      (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
+#  define FMT_FALLTHROUGH [[fallthrough]]
 #else
 #  define FMT_FALLTHROUGH
 #endif


### PR DESCRIPTION
…bel or a default label

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
