### PR TITLE
warning C4267: 'argument': conversion from 'size_t' to 'DWORD', possi…

### DIFF
--- a/include/fmt/format-inl.h
+++ b/include/fmt/format-inl.h
@@ -1351,7 +1351,7 @@ FMT_FUNC void vprint(std::FILE* f, string_view format_str, format_args args) {
     internal::utf8_to_utf16 u16(string_view(buffer.data(), buffer.size()));
     auto written = DWORD();
     if (!WriteConsoleW(reinterpret_cast<HANDLE>(_get_osfhandle(fd)),
-                       u16.c_str(), u16.size(), &written, nullptr)) {
+                       u16.c_str(), static_cast<DWORD>(u16.size()), &written, nullptr)) {
       throw format_error("failed to write to console");
     }
     return;


### PR DESCRIPTION
…ble loss of data

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
