### PR TITLE
Fix for older versions of intel compiler

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -235,7 +235,7 @@ inline Dest bit_cast(const Source& source) {
 }
 
 inline bool is_big_endian() {
-  auto u = 1u;
+  const auto u = 1u;
   struct bytes {
     char data[sizeof(u)];
   };


### PR DESCRIPTION
The intel-17 and intel-18 compilers seem to require that `u` be `const`:
```
/src/fmt/format.h(226): warning #437: reference to local variable of enclosing function is not allowed
        char data[sizeof(u)];
```
If `u` is declared as `const auto u =1u` instead of just `auto u=1u`, the file compiles with no warnings.

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
