### PR TITLE
add const begin and end overload to buffer (#1553)

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -633,6 +633,9 @@ template <typename T> class buffer {
   T* begin() FMT_NOEXCEPT { return ptr_; }
   T* end() FMT_NOEXCEPT { return ptr_ + size_; }
 
+  const T* begin() const FMT_NOEXCEPT { return ptr_; }
+  const T* end() const FMT_NOEXCEPT { return ptr_ + size_; }
+
   /** Returns the size of this buffer. */
   std::size_t size() const FMT_NOEXCEPT { return size_; }
 


### PR DESCRIPTION
* add const begin and end overload to buffer

since there is a const overload for data I think there should also be one for begin and end

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
