### PR TITLE
Make FMT_ASSERT work in constexpr on clang 4.0.1

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -259,9 +259,9 @@ FMT_API void assert_fail(const char* file, int line, const char* message);
 #  ifdef NDEBUG
 #    define FMT_ASSERT(condition, message)
 #  else
-#    define FMT_ASSERT(condition, message) \
-      ((condition)                         \
-           ? void()                        \
+#    define FMT_ASSERT(condition, message)                                    \
+      ((condition) /* void() fails with -Winvalid-constexpr on clang 4.0.1 */ \
+           ? (void)0                                                          \
            : ::fmt::internal::assert_fail(__FILE__, __LINE__, (message)))
 #  endif
 #endif
@@ -947,12 +947,10 @@ template <typename Context> struct arg_mapper {
       map(static_cast<typename std::underlying_type<T>::type>(val))) {
     return map(static_cast<typename std::underlying_type<T>::type>(val));
   }
-  template <
-      typename T,
-      FMT_ENABLE_IF(
-          !is_string<T>::value && !is_char<T>::value &&
-          (has_formatter<T, Context>::value ||
-           has_fallback_formatter<T, Context>::value))>
+  template <typename T,
+            FMT_ENABLE_IF(!is_string<T>::value && !is_char<T>::value &&
+                          (has_formatter<T, Context>::value ||
+                           has_fallback_formatter<T, Context>::value))>
   FMT_CONSTEXPR const T& map(const T& val) {
     return val;
   }


### PR DESCRIPTION
<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
