### PR TITLE
Fix ambiguous overloads of format & format_to

### DIFF
--- a/include/fmt/compile.h
+++ b/include/fmt/compile.h
@@ -351,6 +351,8 @@ template <int N, typename... Args> struct get_type_impl<N, type_list<Args...>> {
 template <int N, typename T>
 using get_type = typename get_type_impl<N, T>::type;
 
+template <typename T> struct is_static_compiled_format : std::false_type {};
+
 template <typename Char> struct text {
   basic_string_view<Char> data;
   using char_type = Char;
@@ -361,6 +363,9 @@ template <typename Char> struct text {
     return copy_str<Char>(data.begin(), data.end(), out);
   }
 };
+
+template <typename Char>
+struct is_static_compiled_format<text<Char>> : std::true_type {};
 
 template <typename Char>
 constexpr text<Char> make_text(basic_string_view<Char> s, size_t pos,
@@ -407,6 +412,9 @@ template <typename Char, typename T, int N> struct field {
   }
 };
 
+template <typename Char, typename T, int N>
+struct is_static_compiled_format<field<Char, T, N>> : std::true_type {};
+
 template <typename L, typename R> struct concat {
   L lhs;
   R rhs;
@@ -418,6 +426,9 @@ template <typename L, typename R> struct concat {
     return rhs.format(out, args...);
   }
 };
+
+template <typename L, typename R>
+struct is_static_compiled_format<concat<L, R>> : std::true_type {};
 
 template <typename L, typename R>
 constexpr concat<L, R> make_concat(L lhs, R rhs) {
@@ -507,19 +518,19 @@ constexpr auto compile(S format_str) {
   }
 }
 
-template <typename CompiledFormat, typename... Args,
-          typename Char = typename CompiledFormat::char_type,
-          FMT_ENABLE_IF(!std::is_base_of<internal::basic_compiled_format,
-                                         CompiledFormat>::value)>
+template <
+    typename CompiledFormat, typename... Args,
+    typename Char = typename CompiledFormat::char_type,
+    FMT_ENABLE_IF(internal::is_static_compiled_format<CompiledFormat>::value)>
 std::basic_string<Char> format(const CompiledFormat& cf, const Args&... args) {
   basic_memory_buffer<Char> buffer;
   cf.format(std::back_inserter(buffer), args...);
   return to_string(buffer);
 }
 
-template <typename OutputIt, typename CompiledFormat, typename... Args,
-          FMT_ENABLE_IF(!std::is_base_of<internal::basic_compiled_format,
-                                         CompiledFormat>::value)>
+template <
+    typename OutputIt, typename CompiledFormat, typename... Args,
+    FMT_ENABLE_IF(internal::is_static_compiled_format<CompiledFormat>::value)>
 OutputIt format_to(OutputIt out, const CompiledFormat& cf,
                    const Args&... args) {
   return cf.format(out, args...);


### PR DESCRIPTION
<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
