### PR TITLE
fix `fmt::get` for some GCC versions and legacy Clang (#2144)

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -3833,21 +3833,16 @@ FMT_CONSTEXPR void advance_to(
     auto s = fmt::format("{}", fmt::ptr(p));
   \endrst
  */
-template <typename T> inline const void* ptr(const T* p) { return p; }
-template <typename T> inline const void* ptr(const std::unique_ptr<T>& p) {
+template <typename T> const void* ptr(T p) {
+  static_assert(std::is_pointer<T>::value, "");
+  return detail::bit_cast<const void*>(p);
+}
+template <typename T> const void* ptr(const std::unique_ptr<T>& p) {
   return p.get();
 }
-template <typename T> inline const void* ptr(const std::shared_ptr<T>& p) {
+template <typename T> const void* ptr(const std::shared_ptr<T>& p) {
   return p.get();
 }
-#if !FMT_MSC_VER
-// MSVC lets function pointers decay to void pointers, so this
-// overload is unnecessary.
-template <typename T, typename... Args>
-inline const void* ptr(T (*fn)(Args...)) {
-  return detail::bit_cast<const void*>(fn);
-}
-#endif
 
 class bytes {
  private:


### PR DESCRIPTION
fixes https://github.com/fmtlib/fmt/issues/2140

- some GCC versions decay function pointers to `const void*`, exactly like
  MSVC does
- legacy Clang (prior to 7.0) treats function pointers also as `const T*`
  pointers, but unable to convert them

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
