### PR TITLE
Fix harmless MSVS warning about using undefined _MANAGED symbol (#2183)

### DIFF
--- a/include/fmt/core.h
+++ b/include/fmt/core.h
@@ -177,7 +177,7 @@
 
 #ifndef FMT_USE_INLINE_NAMESPACES
 #  if FMT_HAS_FEATURE(cxx_inline_namespaces) || FMT_GCC_VERSION >= 404 || \
-      (FMT_MSC_VER >= 1900 && !_MANAGED)
+      (FMT_MSC_VER >= 1900 && (!defined(_MANAGED) || !_MANAGED))
 #    define FMT_USE_INLINE_NAMESPACES 1
 #  else
 #    define FMT_USE_INLINE_NAMESPACES 0


### PR DESCRIPTION
Since the changes of 1305cbeb (Fix MSVC2019 error C2049 when compiling
with /clr (#1897), 2020-09-23), compiling fmt with MSVS 2019 resulted in

fmt\include\fmt\core.h(180,32): warning C4668: '_MANAGED' is not defined
as a preprocessor macro, replacing with '0' for '#if/#elif'.

when the (disabled by default) warning C4668 was enabled.

Fix this simply by checking if _MANAGED is defined before testing it.

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
