### PR TITLE
Fix C++17 builds: (#2192)

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -16,7 +16,7 @@ jobs:
           - os: windows-2016
             standard: 11
           - os: windows-2019
-            standard: 14
+            standard: 17
           - os: windows-2016
             platform: Win32
             build_type: Debug

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,23 +17,15 @@ else ()
   target_compile_definitions(gmock PUBLIC GTEST_HAS_PTHREAD=0)
 endif ()
 
-target_compile_definitions(gmock PUBLIC GTEST_LANG_CXX11=0)
+target_compile_definitions(gmock PUBLIC GTEST_LANG_CXX11=1)
 
 if (MSVC)
-  # Workaround a bug in implementation of variadic templates in MSVC11.
-  target_compile_definitions(gmock PUBLIC _VARIADIC_MAX=10)
-  
   # Disable MSVC warnings of _CRT_INSECURE_DEPRECATE functions.
   target_compile_definitions(gmock PRIVATE _CRT_SECURE_NO_WARNINGS)
   if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     # Disable MSVC warnings of POSIX functions.
     target_compile_options(gmock PUBLIC -Wno-deprecated-declarations)
   endif ()
-endif ()
-
-# GTest doesn't detect <tuple> with clang.
-if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-  target_compile_definitions(gmock PUBLIC GTEST_USE_OWN_TR1_TUPLE=1)
 endif ()
 
 # Silence MSVC tr1 deprecation warning in gmock.


### PR DESCRIPTION
- Fix C++17 Visual Studio builds.
- Use C++17 for `windows-2019` builds.
- Removed options for unsupported compiler (MSVC11).
- Removed options, not needed after enabling C++11+ features in gmock/gtest.

<!-- Please read the contribution guidelines before submitting a pull request. -->
<!-- By submitting this pull request, you agree that your contributions are licensed under the {fmt} license,
     and agree to future changes to the licensing. -->
<!-- If you're a first-time contributor, please acknowledge it by leaving the statement below. -->

I agree that my contributions are licensed under the {fmt} license, and agree to future changes to the licensing.
