### PR TITLE
Ranges wide strings support (#2236)

### DIFF
--- a/include/fmt/format.h
+++ b/include/fmt/format.h
@@ -3720,7 +3720,7 @@ struct formatter<arg_join<It, Sentinel, Char>, Char> {
  private:
   using value_type = typename std::iterator_traits<It>::value_type;
   using formatter_type =
-      conditional_t<has_formatter<value_type, format_context>::value,
+      conditional_t<has_formatter<value_type, buffer_context<Char>>::value,
                     formatter<value_type, Char>,
                     detail::fallback_formatter<value_type, Char>>;
 

--- a/include/fmt/ranges.h
+++ b/include/fmt/ranges.h
@@ -67,6 +67,12 @@ OutputIterator copy(char ch, OutputIterator out) {
   return out;
 }
 
+template <typename OutputIterator>
+OutputIterator copy(wchar_t ch, OutputIterator out) {
+  *out++ = ch;
+  return out;
+}
+
 /// Return true value if T has std::string interface, like std::string_view.
 template <typename T> class is_like_std_string {
   template <typename U>

--- a/test/ranges-test.cc
+++ b/test/ranges-test.cc
@@ -224,6 +224,25 @@ TEST(RangesTest, JoinTuple) {
   EXPECT_EQ("4", fmt::format("{}", fmt::join(t4, "/")));
 }
 
+TEST(RangesTest, WideStringJoinTuple) {
+  // Value tuple args
+  std::tuple<wchar_t, int, float> t1 = std::make_tuple('a', 1, 2.0f);
+  EXPECT_EQ(L"(a, 1, 2)", fmt::format(L"({})", fmt::join(t1, L", ")));
+
+  // Testing lvalue tuple args
+  int x = 4;
+  std::tuple<wchar_t, int&> t2{'b', x};
+  EXPECT_EQ(L"b + 4", fmt::format(L"{}", fmt::join(t2, L" + ")));
+
+  // Empty tuple
+  std::tuple<> t3;
+  EXPECT_EQ(L"", fmt::format(L"{}", fmt::join(t3, L"|")));
+
+  // Single element tuple
+  std::tuple<float> t4{4.0f};
+  EXPECT_EQ(L"4", fmt::format(L"{}", fmt::join(t4, L"/")));
+}
+
 TEST(RangesTest, JoinInitializerList) {
   EXPECT_EQ("1, 2, 3", fmt::format("{}", fmt::join({1, 2, 3}, ", ")));
   EXPECT_EQ("fmt rocks !",


### PR DESCRIPTION
* Ranges copy wchar_t

* arg_join formatter not working for wide strings

* Added ranges wide string tests

Co-authored-by: Cristi <cristi@emailaddressmanager.com>

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree that your contributions are licensed
under the {fmt} license, and agree to future changes to the licensing.
-->
